### PR TITLE
modified docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ This is entirely his code.
 ## Modifications
 
 I've added version and package information to Naoki's README based
-on his [post](https://community.theta360.guide/t/using-usb-api-mtp-with-libghoto2-and-python-bindings-on-macos-raspberry-pi-linux-ros/4521/50?u=craig).  
+on his [post](https://community.theta360.guide/t/using-usb-api-mtp-with-libghoto2-and-python-bindings-on-macos-raspberry-pi-linux-ros/4521/50?u=craig).
+
+Change docstrings to conform to [PEP257](https://www.python.org/dev/peps/pep-0257/)
 
 
 ## Software Version
@@ -29,8 +31,6 @@ $ sudo apt install python-pip
 $ python -m pip install pipenv
 $ pipenv install gphoto2
 $ pipenv shell
-
-
 ```
 
 

--- a/scripts/pytheta.py
+++ b/scripts/pytheta.py
@@ -46,7 +46,7 @@ TIMEOUT = 10
 class no_xtp_dev(Exception):
 	"""
 	JP: xTPデバイスが何もないことを示すエラー
-    EN: Error indicating that there are no xTP devices
+	EN: Error indicating that there are no xTP devices
 	"""
 	def __str__(self):
 		return "xTPデバイスが何もありません"
@@ -56,7 +56,7 @@ def get_xtp_dev_list():
 	"""
 		JP: 接続されているxTPデバイスのリストを作成する。  
 		xTPデバイスとは、PTP、MTPデバイスの総称である。(勝手に名付けた。)
-        EN: Make a list of connected xTP devices.
+		EN: Make a list of connected xTP devices.
 		xTP device is a general term for PTP and MTP devices. (I named it arbitrarily.)
 
 
@@ -86,7 +86,7 @@ def check_if_theta(xtp_dev_list):
 		----------
 		xtp_dev_lis : list
 			JP: 接続されているxTPデバイスのリスト
-            EN: List of connected xTP devices
+			EN: List of connected xTP devices
 
 		Returns
 		-------
@@ -175,22 +175,22 @@ def connect_init():
 
 def camera_control_util(addr):
 	"""
-		JP: Python-gPhoto2において
-		コマンドを送信するThetaを選択して送信する必要がある関数の
-		基本部分をまるっとまとめたユーティリティ。
-		EN: A utility that summarizes the basic parts of a function 
-		that you need in order to select and send to a Theta sending a command in Python-gPhoto2.
+	JP: Python-gPhoto2において
+	コマンドを送信するThetaを選択して送信する必要がある関数の
+	基本部分をまるっとまとめたユーティリティ。
+	EN: A utility that summarizes the basic parts of a function 
+	that you need in order to select and send to a Theta sending a command in Python-gPhoto2.
 
-		Parameters
-		----------
-		addr : char
-			JP: 接続されているThetaのID
-			EN: ID for connected THETA
+	Parameters
+	----------
+	addr : char
+		JP: 接続されているThetaのID
+		EN: ID for connected THETA
 
-		Returns
-		-------
-		camera : Camera object
-		parent_widget : camera widget object
+	Returns
+	-------
+	camera : Camera object
+	parent_widget : camera widget object
 	"""
 
 	camera = gp.Camera()


### PR DESCRIPTION
deleted spaces as we are using tabs for most of the document.
NOTE: we need to look into how to standardize on tabs and spaces, possibly
auto-converting tabs to spaces.  Look at Python best practices.
Added link to docstring style guidelines PEP257
https://www.python.org/dev/peps/pep-0257/